### PR TITLE
Fix upstream regression [1] where login box can be narrower than viewport…

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -50,6 +50,10 @@
           }
         {% endif %}
       }
+      // fix PatternFly regression https://github.com/patternfly/patternfly/pull/2754/files#r401700192
+      .pf-c-login__container {
+        width: 100%;
+      }
       .pf-c-login__main-body {
         padding-bottom: var(--pf-global--spacer--2xl) !important;
       }


### PR DESCRIPTION
… at mobile

[1] https://github.com/patternfly/patternfly/issues/2913

Before:
![localhost_4000_ocp_providers html(iPhone 6_7_8) (2)](https://user-images.githubusercontent.com/895728/78165907-03350700-741a-11ea-984c-ba0ea801b442.png)

After:
![localhost_4000_ocp_providers html(iPhone 6_7_8)](https://user-images.githubusercontent.com/895728/78165922-08925180-741a-11ea-8deb-d03b2e476a55.png)
