### PR TITLE
Scope upstream bug fix to < 1200px viewport sizes

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -51,8 +51,10 @@
         {% endif %}
       }
       // fix PatternFly regression https://github.com/patternfly/patternfly/pull/2754/files#r401700192
-      .pf-c-login__container {
-        width: 100%;
+      @media(max-width: 1199px) {
+        .pf-c-login__container {
+          width: 100%;
+        }
       }
       .pf-c-login__main-body {
         padding-bottom: var(--pf-global--spacer--2xl) !important;


### PR DESCRIPTION
Didn't realize when I implemented [the fix previously](https://github.com/openshift/oauth-templates/pull/9) that it broke centering at very large viewports.  SMH.

After:
white box still goes to edges on mobile
![localhost_4000_ocp_login html(iPhone 6_7_8) (1)](https://user-images.githubusercontent.com/895728/78185067-82d1ce80-7438-11ea-85c2-c59fc0f0f030.png)

contents are still centered at very large resolutions
<img width="1262" alt="Screen Shot 2020-04-01 at 4 46 02 PM" src="https://user-images.githubusercontent.com/895728/78185732-874ab700-7439-11ea-81e9-b102eec0c897.png">

