### PR TITLE
fix invalid HTML

### DIFF
--- a/_includes/logo-ocp.html
+++ b/_includes/logo-ocp.html
@@ -1,4 +1,4 @@
-<svg alt="{{ collection.name }} logo" class="pf-v6-c-brand" version='1.1' viewBox='0 0 320 47.6' xmlns='http://www.w3.org/2000/svg'>
+<svg role="img" aria-label="{{ collection.name }} logo" class="pf-v6-c-brand" version='1.1' viewBox='0 0 320 47.6' xmlns='http://www.w3.org/2000/svg'>
   <style type='text/css'>
     .st0 {
       fill: var(--pf-t--global--text--color--regular);

--- a/_includes/logo-od.html
+++ b/_includes/logo-od.html
@@ -1,4 +1,4 @@
-<svg alt="{{ collection.name }} logo" class="pf-v6-c-brand" version='1.1' viewBox='0 0 240.2 47.6' xmlns='http://www.w3.org/2000/svg'>
+<svg role="img" aria-label="{{ collection.name }} logo" class="pf-v6-c-brand" version='1.1' viewBox='0 0 240.2 47.6' xmlns='http://www.w3.org/2000/svg'>
   <style type='text/css'>
     .st0 {
       fill: var(--pf-t--global--text--color--regular);

--- a/_includes/logo-okd.html
+++ b/_includes/logo-okd.html
@@ -1,4 +1,4 @@
-<svg alt="{{ collection.name }} logo" class="pf-v6-c-brand" version='1.1' viewBox='0 0 104.1 50' xmlns='http://www.w3.org/2000/svg'>
+<svg role="img" aria-label="{{ collection.name }} logo" class="pf-v6-c-brand" version='1.1' viewBox='0 0 104.1 50' xmlns='http://www.w3.org/2000/svg'>
   <style type='text/css'>
     .st0 {
       fill: #F22B29;

--- a/_includes/logo-rho.html
+++ b/_includes/logo-rho.html
@@ -1,4 +1,4 @@
-<svg alt="{{ collection.name }} logo" class="pf-v6-c-brand" version='1.1' viewBox='0 0 142.98 48' xmlns='http://www.w3.org/2000/svg' xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
+<svg role="img" title="{{ collection.name }} logo" class="pf-v6-c-brand" version='1.1' viewBox='0 0 142.98 48' xmlns='http://www.w3.org/2000/svg' xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
   <style>
     .st0 {
       fill: var(--pf-t--global--text--color--regular);

--- a/_includes/logo-rosa.html
+++ b/_includes/logo-rosa.html
@@ -1,4 +1,4 @@
-<svg alt="{{ collection.name }} logo" class="pf-v6-c-brand" version='1.1' viewBox='0 0 290.5 47.6' xmlns='http://www.w3.org/2000/svg'>
+<svg role="img" aria-label="{{ collection.name }} logo" class="pf-v6-c-brand" version='1.1' viewBox='0 0 290.5 47.6' xmlns='http://www.w3.org/2000/svg'>
   <style type='text/css'>
     .st0 {
       fill: var(--pf-t--global--text--color--regular);

--- a/_includes/styles/providers.css
+++ b/_includes/styles/providers.css
@@ -52,6 +52,11 @@ body) {
   list-style: none;
 }
 
+:where(img) {
+  max-width: 100%;
+  height: auto;
+}
+
 :where(a) {
   color: var(--pf-t--global--text--color--link--default);
   text-decoration: var(--pf-t--global--text-decoration--link--line--default);

--- a/_layouts/login.html
+++ b/_layouts/login.html
@@ -34,14 +34,14 @@ layout: base
             class="pf-v6-c-form__label-required" aria-hidden="true">&#42;</span></label>
         <span class="pf-v6-c-form-control pf-m-required">
           <input required type="text" id="inputUsername" name="{{ .Names.Username }}"
-            value="{{ .Values.Username }}" autofocus />
+            value="{{ .Values.Username }}" autofocus>
         </span>
       </div>
       <div class="pf-v6-c-form__group"><label class="pf-v6-c-form__label" for="inputPassword">
           <span class="pf-v6-c-form__label-text">{{ .Locale.Password }}</span>&nbsp;<span
             class="pf-v6-c-form__label-required" aria-hidden="true">&#42;</span></label>
         <span class="pf-v6-c-form-control pf-m-required">
-          <input required type="password" id="inputPassword" name="{{ .Names.Password }}" />
+          <input required type="password" id="inputPassword" name="{{ .Names.Password }}">
         </span>
       </div>
       <div class="pf-v6-c-form__group pf-m-action">


### PR DESCRIPTION
last minute follow on for https://github.com/openshift/cluster-authentication-operator/pull/751 https://github.com/openshift/oauth-server/pull/169

after:

errors.html
![image](https://github.com/user-attachments/assets/aeddb289-0199-4055-9da7-881bf398cbb2)

login.html
![image](https://github.com/user-attachments/assets/4135ecd7-3c09-4890-8530-1d34527bf759)
(note the errors should disappear after the strings are substituted)

providers.html
![image](https://github.com/user-attachments/assets/31b03b34-c6fc-428e-b8c4-cb526be90666)
(note the errors should disappear after the strings are substituted)